### PR TITLE
InfantGuard v2.1.0 - RSSI Enhancement for Bluetooth Scanning

### DIFF
--- a/arduino.cpp
+++ b/arduino.cpp
@@ -4,8 +4,7 @@
 #define BOTLETICS_PWRKEY 6
 
 // Define Sensor Pins
-#define FSR_PIN1 A1
-#define FSR_PIN2 A2
+#define FSR_PIN A1
 #define DHT_PIN 7
 #define DHT_TYPE DHT22
 const int buttonPin = 2;  // Pushbutton pin is in digital 2, which allows interupt capability
@@ -53,8 +52,7 @@ void setup() {
 }
 
 void loop() {
-  int fsrValue1 = analogRead(FSR_PIN1); //Reads and stores FSR value
-  int fsrValue2 = analogRead(FSR_PIN2); //Reads and stores FSR value
+  int fsrValue = analogRead(FSR_PIN); //Reads and stores FSR value
   float temp = dht.readTemperature(true); // Reads and stores FSR value in farenhite
   scanDevices();
   /* Add section that checks for battery level.
@@ -64,7 +62,7 @@ void loop() {
   */
 
   // Activates sytem if child is detected
-  if (fsrValue1 >= childThreshold || fsrValue2 >= childThreshold) {
+  if (fsrValue >= childThreshold) {
     //Get GPS Coordinates
     Serial.println("Child Detected");
     float cord1, cord2, speed_kph, heading, altitude;


### PR DESCRIPTION
This pull request updates the device scanning logic in `arduino.cpp` to make the detection of the parent device more robust. Instead of immediately marking the parent as present or not based on a single scan, the code now tracks repeated failures to find the parent or detect it within range, and only updates the `parentPresent` status if the parent is absent or out of range in at least 3 out of 5 attempts.

**Improvements to parent device detection:**

* Added a `falseParent` counter to track the number of times the parent device is not found or is out of range during scanning.
* Modified the logic to check the RSSI value when the parent device is found; if the RSSI indicates a weak signal (≤ -75), it is treated as out of range and increments the `falseParent` counter.
* Changed the determination of `parentPresent` to be based on whether the parent device is not found or out of range 3 or more times out of 5 scans, making detection more reliable.